### PR TITLE
Fix module products reference

### DIFF
--- a/shopify-sanity/schemaTypes/objects/module/productFeaturesType.tsx
+++ b/shopify-sanity/schemaTypes/objects/module/productFeaturesType.tsx
@@ -11,7 +11,7 @@ export const productFeaturesType = defineField({
     defineField({
       name: 'products',
       type: 'array',
-      of: [{type: 'productReference'}],
+      of: [{type: 'module.product'}],
       validation: (Rule) => Rule.required().max(2),
     }),
     defineField({


### PR DESCRIPTION
## Summary
- correct reference to `module.product` in product features schema

## Testing
- `npm run lint` in `shopify-sanity`
- `npm run lint` in `shopify-sanity-front` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68451c7ed6608326bb8caf2d203c738c